### PR TITLE
Remove IE Requirement in ps1 script

### DIFF
--- a/scripts/SetupWindows.ps1
+++ b/scripts/SetupWindows.ps1
@@ -6,9 +6,9 @@ Remove-Item -Recurse -Force "tmp" -ErrorAction SilentlyContinue | Out-Null
 New-Item -ItemType Directory -Force -Path "tmp"
 
 Write-Output "Getting latest Tachidesk build files"
-$zipball = (Invoke-WebRequest -Uri "https://api.github.com/repos/Suwayomi/Tachidesk/releases/latest").content | Select-String -Pattern 'https[\.:\/A-Za-z0-9]*zipball\/[a-zA-Z0-9.]*' -CaseSensitive
+$zipball = (Invoke-WebRequest -Uri "https://api.github.com/repos/Suwayomi/Tachidesk/releases/latest" -UseBasicParsing).content | Select-String -Pattern 'https[\.:\/A-Za-z0-9]*zipball\/[a-zA-Z0-9.]*' -CaseSensitive
 
-Invoke-WebRequest -Uri $zipball.Matches.Value -OutFile tmp/Tachidesk.zip
+Invoke-WebRequest -Uri $zipball.Matches.Value -OutFile tmp/Tachidesk.zip -UseBasicParsing
 
 Expand-Archive -Path "tmp/Tachidesk.zip" -DestinationPath "tmp"
 


### PR DESCRIPTION
PowerShell 5 is on windows by default and uses IE by default which is no longer support on windows 10